### PR TITLE
Show human friendly contract address previews in services table

### DIFF
--- a/src/components/services.js
+++ b/src/components/services.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Eth from 'ethjs';
 import {Layout, Divider, Card, Icon, Spin, Alert, Row, Col, Button, Tag, message, Table} from 'antd';
-import {NETWORKS, AGENT_STATE, AGI} from '../util';
+import {NETWORKS, AGENT_STATE, AGI, FORMAT_UTILS} from '../util';
 
 class Services extends React.Component {
 
@@ -22,12 +22,12 @@ class Services extends React.Component {
       {
         title:      'Contract Address',
         dataIndex:  'address',
-        width:      300,
+        width:      '20ch',
         render:     (address, agent, index) =>
           this.props.network &&
           <Tag>
             <a target="_blank" href={`${NETWORKS[this.props.network].etherscan}/address/${address}`}>
-              {address}
+              {FORMAT_UTILS.toHumanFriendlyAddressPreview(address)}
             </a>
           </Tag>
       },
@@ -39,6 +39,7 @@ class Services extends React.Component {
       {
         title:      'Agent Endpoint',
         dataIndex:  'endpoint',
+        width: '23ch'
       },
       {
         title:      '',

--- a/src/util.js
+++ b/src/util.js
@@ -32,3 +32,23 @@ export class AGI {
     return agi / 100000000;
   }
 }
+
+export class FORMAT_UTILS {
+  /**
+   * Shortens a long ethereum address to a human-friendly abbreviated one. Assumes the address starts with '0x'.
+   *
+   * An address like 0x2ed982c220fed6c9374e63804670fc16bd481b8f provides no more value to a human than
+   * a shortened version like 0x2ed9...1b8f. However, screen real estate is precious, especially to real users
+   * and not developers with high-res monitors.
+   */
+  static toHumanFriendlyAddressPreview(address) {
+    const addressPrefix = '0x';
+    const previewLength = 4;
+
+    const addressToShorten = address.startsWith(addressPrefix) ? address.substring(addressPrefix.length) : address;
+    const previewPrefix    = addressToShorten.substring(0, previewLength);
+    const previewSuffix    = addressToShorten.substring(addressToShorten.length - previewLength);
+
+    return `0x${previewPrefix}...${previewSuffix}`;
+  }
+}


### PR DESCRIPTION
An address like 0x2ed982c220fed6c9374e63804670fc16bd481b8f provides no more value to a human than a shortened version like 0x2ed9...1b8f. However, screen real estate is precious, especially to users who are not developers with high-res monitors.

This change shortens the service contract addresses in the table to shortened versions, the main motivation being that otherwise the "Create Job" button is cut off on a maximized 13" MBP screen.

Before:
<img width="1392" alt="maximized13mbp_before" src="https://user-images.githubusercontent.com/3114081/41310864-95da1f54-6e37-11e8-844b-1b4596928029.png">

After: 
<img width="1392" alt="maximized13mbp_after" src="https://user-images.githubusercontent.com/3114081/41310863-95be858c-6e37-11e8-8b8d-677929bf57c7.png">