### PR TITLE
Auto scroll to Job card after selecting an Agent

### DIFF
--- a/src/components/job.js
+++ b/src/components/job.js
@@ -35,6 +35,10 @@ class Job extends React.Component {
     abiDecoder.addABI(jobAbi);
   }
 
+  componentDidMount() {
+    this.jobDomNode.scrollIntoView();
+  }
+
   nextJobStep() {
     this.clearModal();
     this.setState((prevState) => ({
@@ -316,7 +320,7 @@ class Job extends React.Component {
 
           <Divider orientation="left">Job Details</Divider>
 
-          <table>
+          <table ref={jobDomNode => this.jobDomNode = jobDomNode}>
             <tbody>
               <tr>
                 <td width="120px"><b>Agent:</b></td>


### PR DESCRIPTION
With this change, the dapp auto-scrolls to the Job card and configuration after you click "Create Job".

note: for some reason I was not able to attach a ref onto a React.Fragment, so I attached it to the table.