### PR TITLE
waitForTransaction: Check if the tx has been executed 

### DIFF
--- a/src/components/job.js
+++ b/src/components/job.js
@@ -120,33 +120,12 @@ class Job extends React.Component {
         waitingForMetaMask: false,
       });
 
-      this.waitForTransaction(response).then(receipt => {
-        /**
-         * Here we are waiting for the transaction to be mined 
-         * But not checking if the execution is succesfull or not
-         * 
-         * For now It's important to enforce at least the `fundJob` step
-         * 
-         * For example in the approveTokens step, even if there is not enough balance
-         * It will be succesfull anyway. This isn't good either if it used in combo 
-         * with ERC20 decreaseApproval function can lead to other bugs 
-         * https://github.com/OpenZeppelin/openzeppelin-solidity/issues/437
-         * 
-         * The createJob step will fail only if someone changes the parameters manually
-         * or in absence of ethers for gas, but this is already enforced by MetaMask 
-         */
+      return this.waitForTransaction(response);
+    }).then(receipt => {
 
-        if (receipt.status === "0x1") {
-          console.log('FundJob called on Job: ' + this.state.jobAddress);
-          this.nextJobStep()
-        } else {
-            // TODO think a better way to show feedback to user
-            this.handleReject('Transaction has not been executed! Check your AGI balance')
-        }
-      });
-       // REFACTOR We should chain the promises, 
-       // in order to use a single higl level `catch`
-       // instead of a Matryoshka style promises  
+      console.log('FundJob called on Job: ' + this.state.jobAddress);
+      this.nextJobStep();
+    
     }).catch(this.handleReject);
   }
 
@@ -196,6 +175,11 @@ class Job extends React.Component {
     while(!receipt) {
       receipt = await window.ethjs.getTransactionReceipt(hash);
     }
+
+    if (receipt.status === "0x0") {
+      throw "Transaction has not been executed! Check your AGI balance";
+    }
+
     return receipt;
   }
   

--- a/src/components/job.js
+++ b/src/components/job.js
@@ -3,7 +3,7 @@ import { abi as agentAbi } from 'singularitynet-alpha-blockchain/Agent.json';
 import { abi as jobAbi } from 'singularitynet-alpha-blockchain/Job.json';
 import Eth from 'ethjs';
 import {Layout, Divider, Card, Icon, Spin, Alert, Row, Col, Button, Tag, message, Table, Collapse, Steps, Modal, Upload} from 'antd';
-import { NETWORKS, AGENT_STATE, AGI } from '../util';
+import { NETWORKS, ERROR_UTILS, AGENT_STATE, AGI } from '../util';
 import {JsonRpcClient} from "../jsonrpc";
 import abiDecoder from 'abi-decoder';
 
@@ -60,8 +60,7 @@ class Job extends React.Component {
   }
 
   handleReject(error) {
-    console.log('User rejected transaction');
-    console.log(error);
+    console.log(ERROR_UTILS.sanitizeError(error));
     this.clearModal();
   }
 
@@ -177,7 +176,7 @@ class Job extends React.Component {
     }
 
     if (receipt.status === "0x0") {
-      throw "Transaction has not been executed! Check your AGI balance";
+      throw receipt
     }
 
     return receipt;

--- a/src/util.js
+++ b/src/util.js
@@ -55,3 +55,31 @@ export class FORMAT_UTILS {
     return `0x${previewPrefix}...${previewSuffix}`;
   }
 }
+
+const errorMessage = {
+  reject: "User rejected transaction submission or message signing",
+  failed: "Transaction mined, but not executed",
+  internal: "Internal Server Error",
+  unknown: "Unknown error"
+}
+
+export class ERROR_UTILS {
+
+  static sanitizeError(error) {
+    console.log
+    if (typeof error === 'object' && error.hasOwnProperty("value")) {
+         // It checks for rejection on both cases of message or transaction
+      if (error.value.message.indexOf("User denied") != -1) {
+        return errorMessage.reject;
+      } else if (error.value.code > -31099 && error.value.code < -32100) {
+        return errorMessage.internal
+      }
+    } else if (typeof error === 'object' && error.hasOwnProperty("status") && error.status === "0x0") {
+      //This is the receipt
+      return `${errorMessage.failed} TxHash: ${error.transactionHash}`
+    }
+
+    return errorMessage.unknown
+  }
+
+}

--- a/src/util.js
+++ b/src/util.js
@@ -56,30 +56,38 @@ export class FORMAT_UTILS {
   }
 }
 
-const errorMessage = {
+const ERROR_MESSAGE = {
   reject: "User rejected transaction submission or message signing",
   failed: "Transaction mined, but not executed",
   internal: "Internal Server Error",
   unknown: "Unknown error"
 }
 
+const RPC_ERROR_BOUNDS = {
+  internal: [-31099, -32100]
+}
+
 export class ERROR_UTILS {
 
   static sanitizeError(error) {
-    console.log
     if (typeof error === 'object' && error.hasOwnProperty("value")) {
-         // It checks for rejection on both cases of message or transaction
+      // It checks for rejection on both cases of message or transaction
       if (error.value.message.indexOf("User denied") != -1) {
-        return errorMessage.reject;
-      } else if (error.value.code > -31099 && error.value.code < -32100) {
-        return errorMessage.internal
+        return ERROR_MESSAGE.reject;
+      } 
+      
+    //Checks for Internal server error 
+      if (error.value.code > RPC_ERROR_BOUNDS.internal[0]  && error.value.code <  RPC_ERROR_BOUNDS.internal[1] ) {
+        return ERROR_MESSAGE.internal
       }
-    } else if (typeof error === 'object' && error.hasOwnProperty("status") && error.status === "0x0") {
-      //This is the receipt
-      return `${errorMessage.failed} TxHash: ${error.transactionHash}`
     }
 
-    return errorMessage.unknown
+    if (typeof error === 'object' && error.hasOwnProperty("status") && error.status === "0x0") {
+      //This is the receipt
+      return `${ERROR_MESSAGE.failed} TxHash: ${error.transactionHash}`
+    }
+
+    return ERROR_MESSAGE.unknown
   }
 
 }


### PR DESCRIPTION
Atm if you don't have enough AGI balance and the fundJob transaction fails, the dapp does not check this and keeps going 

(Metamask displays that there is an error in the tx, but we should double check on our side in order to prevent moving to the next step and waste an API call)